### PR TITLE
Fix/follow : 팔로우 버튼 최종 구현 완료

### DIFF
--- a/src/components/CardDetailCarousel/CardDetailCarousel.js
+++ b/src/components/CardDetailCarousel/CardDetailCarousel.js
@@ -101,7 +101,7 @@ const CardDetailCarousel = ({ URI }) => {
               </div>
             </div>
           </div>
-          <Follow writerInfo={writerInfo} URI={URI} />
+          <Follow writerInfo={writerInfo} URI={URI} type={'short'} />
         </div>
         {/* Carousel */}
         {works === null ? (

--- a/src/components/Follow/Follow.js
+++ b/src/components/Follow/Follow.js
@@ -52,12 +52,6 @@ const Follow = ({ type, writerInfo, URI }) => {
     }
   }, [params.id]);
 
-  //클릭 여부 확인
-  const [isClick, setIsClick] = useState(!isFollow);
-  const handleToggle = () => {
-    setIsClick(!isClick);
-  };
-
   //팔로우,언팔로우 함수
   const sendResult = e => {
     if (e.target.className.includes('FollowingBtn')) {
@@ -71,7 +65,11 @@ const Follow = ({ type, writerInfo, URI }) => {
         body: JSON.stringify({
           following_id: writerInfo.id,
         }),
-      });
+      })
+        .then(res => res.json())
+        .then(json => {
+          setIsFollow(json.follow_check);
+        });
     } else if (e.target.className.includes('FollowBtn')) {
       //POST 작가id, 토큰
       fetch('http://' + URI + ':8000/follow', {
@@ -83,30 +81,25 @@ const Follow = ({ type, writerInfo, URI }) => {
         body: JSON.stringify({
           following_id: writerInfo.id,
         }),
-      });
+      })
+        .then(res => res.json())
+        .then(json => {
+          setIsFollow(json.follow_check);
+        });
     }
   };
+
   const checkFollow = () => {
     if (isLogin && isFollow) {
       return (
-        <div
-          className={
-            isClick ? `${css.shortFollowingBtn}` : `${css.shortFollowBtn}`
-          }
-          onClick={sendResult}
-        >
-          {isClick ? '팔로잉' : '팔로우'}
+        <div className={css.shortFollowingBtn} onClick={sendResult}>
+          팔로잉
         </div>
       );
     } else if (isLogin && isFollow === false) {
       return (
-        <div
-          className={
-            isClick ? `${css.shortFollowBtn}` : `${css.shortFollowingBtn}`
-          }
-          onClick={sendResult}
-        >
-          {isClick ? '팔로우' : '팔로잉'}
+        <div className={css.shortFollowBtn} onClick={sendResult}>
+          팔로우
         </div>
       );
     } else {
@@ -118,7 +111,7 @@ const Follow = ({ type, writerInfo, URI }) => {
     }
   };
   return (
-    <div className={css.followBtns} onClick={handleToggle}>
+    <div className={css.followBtns}>
       {/* login창 로직 추가 코드 */}
       {openLoginpage && (
         <Login

--- a/src/components/Follow/Follow.js
+++ b/src/components/Follow/Follow.js
@@ -159,8 +159,6 @@ const Follow = ({ type, writerInfo, URI }) => {
       )}
       {openJoinPage && <Join setJoinPage={setJoinPage} />}
       {/* login창 로직 추가 코드 종료*/}
-
-      {/* //TODO 현재 로그인 되어있는 사람 id값이랑 해당 작품의 작가의 id가 같으면 팔로우버튼 안보이게 해버리자 */}
       {type === 'short' ? checkShortFollow() : checkLongFollow()}
     </div>
   );

--- a/src/components/Follow/Follow.js
+++ b/src/components/Follow/Follow.js
@@ -55,6 +55,7 @@ const Follow = ({ type, writerInfo, URI }) => {
 
   //팔로우,언팔로우 함수
   const sendResult = e => {
+    console.log('클릭!');
     if (e.target.className.includes('FollowingBtn')) {
       //DELETE 작가id, 토큰
       fetch('http://' + URI + ':8000/follow', {
@@ -95,7 +96,7 @@ const Follow = ({ type, writerInfo, URI }) => {
     }
   };
 
-  const checkFollow = () => {
+  const checkShortFollow = () => {
     if (isLogin && isFollow) {
       return (
         <div className={css.shortFollowingBtn} onClick={sendResult}>
@@ -118,6 +119,30 @@ const Follow = ({ type, writerInfo, URI }) => {
       );
     }
   };
+
+  const checkLongFollow = () => {
+    if (isLogin && isFollow) {
+      return (
+        <div className={css.longFollowingBtn} onClick={sendResult}>
+          팔로잉
+        </div>
+      );
+    } else if (isLogin && isFollow === false) {
+      return (
+        <div className={css.longFollowBtn} onClick={sendResult}>
+          팔로우
+        </div>
+      );
+    } else if (isLogin && errorMessage) {
+      alert('잠시 후 다시 시도해주세요.');
+    } else {
+      return (
+        <div className={css.longFollowBtn} onClick={clickLoginBtn}>
+          팔로우
+        </div>
+      );
+    }
+  };
   return (
     <div className={css.followBtns}>
       {/* login창 로직 추가 코드 */}
@@ -132,7 +157,7 @@ const Follow = ({ type, writerInfo, URI }) => {
       {/* login창 로직 추가 코드 종료*/}
 
       {/* //TODO 현재 로그인 되어있는 사람 id값이랑 해당 작품의 작가의 id가 같으면 팔로우버튼 안보이게 해버리자 */}
-      {checkFollow()}
+      {type === 'short' ? checkShortFollow() : checkLongFollow()}
     </div>
   );
 };

--- a/src/components/Follow/Follow.js
+++ b/src/components/Follow/Follow.js
@@ -6,6 +6,7 @@ import { useParams } from 'react-router-dom';
 
 const Follow = ({ type, writerInfo, URI }) => {
   const [isFollow, setIsFollow] = useState(false);
+  const [errorMessage, setErrorMessage] = useState('');
 
   //login창 로직 추가 코드
   const [openLoginpage, setOpenLoginPage] = useState(false);
@@ -50,7 +51,7 @@ const Follow = ({ type, writerInfo, URI }) => {
           setIsFollow(json.follow_check);
         });
     }
-  }, [params.id]);
+  }, [params.id, URI, token]);
 
   //팔로우,언팔로우 함수
   const sendResult = e => {
@@ -84,7 +85,12 @@ const Follow = ({ type, writerInfo, URI }) => {
       })
         .then(res => res.json())
         .then(json => {
-          setIsFollow(json.follow_check);
+          if (json.follow_check) {
+            setIsFollow(json.follow_check);
+            setErrorMessage('');
+          } else {
+            setErrorMessage(json.message);
+          }
         });
     }
   };
@@ -102,6 +108,8 @@ const Follow = ({ type, writerInfo, URI }) => {
           팔로우
         </div>
       );
+    } else if (isLogin && errorMessage) {
+      alert('잠시 후 다시 시도해주세요.');
     } else {
       return (
         <div className={css.shortFollowBtn} onClick={clickLoginBtn}>

--- a/src/components/Follow/Follow.js
+++ b/src/components/Follow/Follow.js
@@ -39,15 +39,12 @@ const Follow = ({ type, writerInfo, URI }) => {
   useEffect(() => {
     if (token) {
       //팔로우 버튼 데이터 가져오기
-      fetch(
-        'http://' + URI + ':8000/works/feed/' + params.id + '/followcheck',
-        {
-          headers: {
-            'Content-Type': 'application/json',
-            Authorization: token,
-          },
-        }
-      )
+      fetch('http://' + URI + ':8000/follow/' + params.id, {
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: token,
+        },
+      })
         .then(res => res.json())
         .then(json => {
           setIsFollow(json.follow_check);

--- a/src/components/Follow/Follow.js
+++ b/src/components/Follow/Follow.js
@@ -55,7 +55,6 @@ const Follow = ({ type, writerInfo, URI }) => {
 
   //팔로우,언팔로우 함수
   const sendResult = e => {
-    console.log('클릭!');
     if (e.target.className.includes('FollowingBtn')) {
       //DELETE 작가id, 토큰
       fetch('http://' + URI + ':8000/follow', {

--- a/src/components/Follow/Follow.js
+++ b/src/components/Follow/Follow.js
@@ -95,8 +95,11 @@ const Follow = ({ type, writerInfo, URI }) => {
     }
   };
 
+  let loginId = localStorage.getItem('id');
   const checkShortFollow = () => {
-    if (isLogin && isFollow) {
+    if (isLogin && Number(loginId) === Number(writerInfo.id)) {
+      return <div></div>;
+    } else if (isLogin && isFollow) {
       return (
         <div className={css.shortFollowingBtn} onClick={sendResult}>
           팔로잉
@@ -120,7 +123,9 @@ const Follow = ({ type, writerInfo, URI }) => {
   };
 
   const checkLongFollow = () => {
-    if (isLogin && isFollow) {
+    if (isLogin && Number(loginId) === Number(writerInfo.id)) {
+      return <div></div>;
+    } else if (isLogin && isFollow) {
       return (
         <div className={css.longFollowingBtn} onClick={sendResult}>
           팔로잉

--- a/src/components/Follow/Follow.module.scss
+++ b/src/components/Follow/Follow.module.scss
@@ -51,7 +51,7 @@
     cursor: pointer;
     background : {
       color: #00d084;
-      image: url('../../assets/image/check.png');
+      image: url('../../assets/image/following.png');
       size: 18px;
       repeat: no-repeat;
       position: 43% 50%;


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)

- [ ] 레이아웃 구현
- [x] 기능 추가
- [ ] 리뷰 반영
- [x] 리팩토링
- [x] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표

- 팔로우 버튼 컴포넌트화 및 리팩토링

<br />

## :: 구현 사항 설명

1. 팔로우 버튼 컴포넌트화
- 'type' props 추가하여 채널페이지에서 컴포넌트 사용 시 따로 scss코드를 만질 필요가 없도록 구현
 
2. 팔로우 버튼 기능 오류 수정
- 불안정한 팔로우 기능 수정

3. 팔로우 버튼 레이아웃 변경 조건 수정
- 수정 전 : 백에서의 팔로우 요청 성공/실패와 상관없이 클릭 시 버튼의 레이아웃이 팔로우 -> 팔로잉으로 변경됨
- 수정 후 : 백에서의 응답을 기준으로 버튼의 레이아웃이 변경됨

4. 중복 팔로우 요청 시 alert창 추가

5. 팔로우/언팔로우 요청 uri 수정
- 백에서의 수정 사항 반영함

6. 로그인 한 사람과 해당 작품의 작가가 동일인물이라면 팔로우 버튼 자체가 안보이게 처리함

<br />

## :: 성장 포인트

- 사용자 입장에서 생길 수 있는 다양한 상황을 고려하게 되었습니다.

<br />

## :: 기타 질문 및 특이 사항

- 채널 페이지에서 Follow컴포넌트 사용 시 type은 없어도 됩니다(short만 아니면 됩니다).
